### PR TITLE
feat: add conda environment option of installation

### DIFF
--- a/docs/text/installation.rst
+++ b/docs/text/installation.rst
@@ -36,6 +36,22 @@ We recommend using a virtual python environment.
     cd double_pendulum
     make install
 
+Another option to install and use dependencies would be using [conda/mamba](https://github.com/mamba-org/mamba) environment.
+
+1. Clone the repository::
+
+    git clone git@github.com:dfki-ric-underactuated-lab/double_pendulum.git
+
+2. Create a new conda environment::
+
+    cd double_pendulum
+    mamba env create --file=environment.yaml
+
+3. Activate the environment and install the double pendulum package::
+
+    mamba activate double_pendulum
+    make install
+
 With this you are done and you can use all functionalities and some controllers in this repository.
 If you want install all requirements (this includes also larger depoendencies
 such as tensorflow, drake etc.) for all controllers do

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,8 @@
+name: double_pendulum
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - yaml-cpp
+  - eigenpy
+  - cxx-compiler

--- a/src/cpp/python/setup.py
+++ b/src/cpp/python/setup.py
@@ -2,15 +2,31 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
 import numpy as np
+import os
 
+# check if running inside conda/mamba environment
+conda_prefix = os.getenv("CONDA_PREFIX")
+if conda_prefix is not None:
+    # use conda environment include directories
+    include_dirs = [
+        f"{conda_prefix}/include/eigen3",
+        f"{conda_prefix}/include",
+    ]
+else:
+    # use default include directories
+    include_dirs = []
 
 ilqr_extension = Extension(
     name="cppilqr",
     sources=["cppilqr.pyx"],
     libraries=["ilqr", "yaml-cpp"],
     library_dirs=["../controllers/ilqr/obj"],
-    include_dirs=["../controllers/ilqr/obj", np.get_include()],
-    language="c++"
+    include_dirs=[
+        "../controllers/ilqr/obj",
+        np.get_include(),
+    ]
+    + include_dirs,
+    language="c++",
 )
 setup(
     name="cppilqr",


### PR DESCRIPTION
Hello, DFKI RIC Team!

I was looking through the repository and was surprised that installation procedure requires system-wide installation of some packages. I thought that the proper option would be to use conda/mamba/pixi environment because it allows more people to be independent of the platform and dependencies.

I have added conda environment description that installs the dependencies needed and updated setup.py to include other paths. The run of `make install` is successfull and `ilqr` examples run without problems.

Please give your thoughts, whether it is suitable for the project or not. Looking forward for your feedback!

Best Regards,
Kozlov Lev